### PR TITLE
Remove obsolete code remnants. Test concurrency of Disposer.disposes …

### DIFF
--- a/pico-disposal/src/main/scala/org/pico/disposal/Disposer.scala
+++ b/pico-disposal/src/main/scala/org/pico/disposal/Disposer.scala
@@ -6,6 +6,8 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong, At
 import org.pico.disposal.std.autoCloseable._
 import org.pico.disposal.syntax.disposable._
 
+import scala.util.control.NonFatal
+
 /** The Disposer disposes disposable objects that are registered with it when it is closed.
   *
   * The disposer is thread-safe, but will not prevent more disposable object from being registered
@@ -148,7 +150,7 @@ trait Disposer extends Closeable {
     try {
       disposes(disposable)
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         this.dispose()
         throw e
     }

--- a/pico-disposal/src/main/scala/org/pico/disposal/SimpleDisposer.scala
+++ b/pico-disposal/src/main/scala/org/pico/disposal/SimpleDisposer.scala
@@ -3,6 +3,7 @@ package org.pico.disposal
 import java.io.Closeable
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
+import org.pico.atomic.syntax.std.atomicBoolean._
 import org.pico.atomic.syntax.std.atomicReference._
 import org.pico.disposal.std.autoCloseable._
 import org.pico.disposal.syntax.disposable._
@@ -16,14 +17,12 @@ trait SimpleDisposer extends Disposer {
 
   @inline
   final override def disposes[D: Disposable](disposable: D): D = {
-    if (!closed.get) {
-      disposables.update(_ :+: disposable.asCloseable)
+    disposables.update(_ :+: disposable.asCloseable)
 
-      if (closed.get) {
-        // It is possible that the object was closed the first `closed` test.  If that's the
-        // case we want to ensure that the `disposable` argument is also closed.
-        disposables.getAndSet(Closed).dispose()
-      }
+    if (closed.value) {
+      // It is possible that the object was closed the first `closed` test.  If that's the
+      // case we want to ensure that the `disposable` argument is also closed.
+      disposables.getAndSet(Closed).dispose()
     }
 
     disposable

--- a/pico-disposal/src/main/scala/org/pico/disposal/syntax/disposable/package.scala
+++ b/pico-disposal/src/main/scala/org/pico/disposal/syntax/disposable/package.scala
@@ -24,10 +24,35 @@ package object disposable {
       * @return The Closeable wrapper
       */
     @inline
-    final def asCloseable(implicit ev: Disposable[A]): Closeable = ev.asCloseable(self)
+    final def wrapInCloseable(implicit ev: Disposable[A]): Closeable = ev.wrapInCloseable(self)
 
+    /** Get Closeable of the disposable, creating a Closeable wrapper if necessary.  Calling close
+      * on the wrapper will directly call onDispose on the disposable object.  It does not call
+      * the dispose method because the dispose method will silently catch non-fatal exceptions.
+      * Callers may choose this method instead of calling dispose to get access to any thrown
+      * exceptions.
+      *
+      * @param ev Evidence that A is disposable.
+      * @return The Closeable wrapper
+      */
     @inline
-    final def disposablePoisoned(implicit ev: Disposable[A]): Boolean = ev.disposablePoisoned(self)
+    final def asCloseable(implicit ev: Disposable[A]): Closeable = {
+      self.asAutoCloseable match {
+        case closeable: Closeable => closeable
+        case _                    => wrapInCloseable
+      }
+    }
+
+    /** Create a wrapper for the disposable object that implements AutoCloseable.  Calling close on
+      * the wrapper will directly call onDispose on the disposable object.  It does not call the
+      * dispose method because the dispose method will silently catch non-fatal exceptions.  Callers
+      * may choose this method instead of calling dispose to get access to any thrown exceptions.
+      *
+      * @param ev Evidence that A is disposable.
+      * @return The Closeable wrapper
+      */
+    @inline
+    final def asAutoCloseable(implicit ev: Disposable[A]): AutoCloseable = ev.asAutoCloseable(self)
 
     /** Compose two disposable objects into a single Closeable object that when closed will dispose
       * both disposable objects.

--- a/pico-disposal/src/test/scala/org/pico/disposal/DisposableSpec.scala
+++ b/pico-disposal/src/test/scala/org/pico/disposal/DisposableSpec.scala
@@ -5,17 +5,15 @@ import org.pico.disposal.syntax.disposable._
 import org.specs2.mutable.Specification
 
 class DisposableSpec extends Specification {
-  "Disposable" >> {
-    "when composed" should {
-      "dispose in reverse order" >> {
-        var value = 1
-        val disposable1 = OnClose(value += 1)
-        val disposable2 = OnClose(value *= 10)
+  "Disposable should" should {
+    "when composed dispose in reverse order" >> {
+      var value = 1
+      val disposable1 = OnClose(value += 1)
+      val disposable2 = OnClose(value *= 10)
 
-        (disposable1 :+: disposable2).dispose()
+      (disposable1 :+: disposable2).dispose()
 
-        value ==== 11
-      }
+      value ==== 11
     }
 
     "dispose in reverse order in nested for comprehension" >> {
@@ -38,6 +36,40 @@ class DisposableSpec extends Specification {
       }: String
 
       x ==== 11
+    }
+
+    "have asCloseable method" in {
+      Closed.asCloseable must_=== Closed
+    }
+
+    "have asCloseable method for not Closeable types" in {
+      var count = 0
+      class NewType()
+      implicit val disposable_NewType = new Disposable[NewType] {
+        override protected def onDispose(a: NewType): Unit = {
+          count += 1
+        }
+      }
+      val newType = new NewType()
+      newType.asAutoCloseable.dispose()
+      newType.asCloseable.close()
+      count must_=== 2
+    }
+
+    "have asAutoCloseable method" in {
+      Closed.asAutoCloseable must_=== Closed
+    }
+
+    "have dispose method that suppresses exception" in {
+      class NewType()
+      implicit val disposable_NewType = new Disposable[NewType] {
+        override protected def onDispose(a: NewType): Unit = {
+          throw new Exception()
+        }
+      }
+      val newType = new NewType()
+      newType.dispose()
+      ok
     }
   }
 }

--- a/pico-disposal/src/test/scala/org/pico/disposal/DisposerSpec.scala
+++ b/pico-disposal/src/test/scala/org/pico/disposal/DisposerSpec.scala
@@ -1,8 +1,13 @@
 package org.pico.disposal
 
 import java.io.Closeable
-import java.util.concurrent.atomic.AtomicReference
+import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong, AtomicReference}
 
+import org.pico.atomic.syntax.std.atomicBoolean._
+import org.pico.atomic.syntax.std.atomicInteger._
+import org.pico.atomic.syntax.std.atomicLong._
+import org.pico.atomic.syntax.std.atomicReference._
 import org.pico.disposal.std.autoCloseable._
 import org.pico.disposal.syntax.disposable._
 import org.specs2.mutable.Specification
@@ -14,7 +19,7 @@ class DisposerSpec extends Specification {
       val disposer = Disposer()
 
       disposer.disposes(OnClose(value += 1))
-      disposer.disposes(OnClose(value *= 10))
+      disposer +=       OnClose(value *= 10)
       disposer.dispose()
 
       value ==== 11
@@ -25,7 +30,7 @@ class DisposerSpec extends Specification {
       val disposer = Disposer()
       val reference = disposer.swapReleases(Closed, new AtomicReference[Closeable](OnClose(log ::= "closed")))
       disposer.dispose()
-      reference.get() ==== Closed
+      reference.value ==== Closed
       log ==== List()
     }
 
@@ -34,7 +39,7 @@ class DisposerSpec extends Specification {
       val disposer = Disposer()
       val reference = disposer.swapReleases(Closed, new AtomicReference[AutoCloseable](OnClose(log ::= "closed")))
       disposer.dispose()
-      reference.get() ==== Closed
+      reference.value ==== Closed
       log ==== List()
     }
 
@@ -43,7 +48,7 @@ class DisposerSpec extends Specification {
       val disposer = Disposer()
       val reference = disposer.swapDisposes(Closed, new AtomicReference[Closeable](OnClose(log ::= "closed")))
       disposer.dispose()
-      reference.get() ==== Closed
+      reference.value ==== Closed
       log ==== List("closed")
     }
 
@@ -52,8 +57,91 @@ class DisposerSpec extends Specification {
       val disposer = Disposer()
       val reference = disposer.swapDisposes(Closed, new AtomicReference[AutoCloseable](OnClose(log ::= "closed")))
       disposer.dispose()
-      reference.get() ==== Closed
+      reference.value ==== Closed
       log ==== List("closed")
+    }
+
+    "be able to close disposable objects registered concurrently with close" in {
+      val disposer = Disposer()
+      val counter = new AtomicInteger(0)
+      val thread = new Thread {
+        override def run(): Unit = {
+          disposer.disposes(OnClose {
+            Thread.sleep(10)
+            counter.incrementAndGet()
+          })
+          Thread.sleep(20)
+        }
+      }
+
+      thread.start()
+      disposer.close()
+      thread.join()
+
+      counter.value must_=== 1
+
+      success
+    }
+
+    "be able to register side-effects to run upon closing" in {
+      val count = new AtomicInteger(0)
+
+      for (disposer <- Disposer()) {
+        disposer.onClose(count.incrementAndGet())
+      }
+
+      count.value must_=== 1
+    }
+
+    "be able to register reset of AtomicLong to a value upon closing" in {
+      val disposer = Disposer()
+      val count = disposer.resets(0, new AtomicLong(123))
+      count.value must_=== 123L
+      disposer.close()
+      count.value must_=== 0L
+    }
+
+    "be able to register reset of AtomicInteger to a value upon closing" in {
+      val disposer = Disposer()
+      val count = disposer.resets(0, new AtomicInteger(123))
+      count.value must_=== 123
+      disposer.close()
+      count.value must_=== 0
+    }
+
+    "be able to register reset of AtomicBoolean to a value upon closing" in {
+      val disposer = Disposer()
+      val flag = disposer.resets(true, new AtomicBoolean(false))
+      flag.value must_=== false
+      disposer.close()
+      flag.value must_=== true
+    }
+
+    "be able to register reset of AtomicReference to a value upon closing" in {
+      val disposer = Disposer()
+      val flag = disposer.resets(true, new AtomicReference(false))
+      flag.value must_=== false
+      disposer.close()
+      flag.value must_=== true
+    }
+
+    "be able to register release of reference upon closing" in {
+      "and not release when not closed" in {
+        val disposer = Disposer()
+        val weakRef = new WeakReference(disposer.releases(new Object()))
+        weakRef.get() must not be null
+        System.gc()
+        weakRef.get() must not be null
+      }
+
+      "and release when not closed" in {
+        val disposer = Disposer()
+        val weakRef = new WeakReference(disposer.releases(new Object()))
+        weakRef.get() must not be null
+        disposer.close()
+        System.gc()
+        weakRef.get() must_=== null
+      }
     }
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt.Keys._
 import sbt._
 
 object Build extends sbt.Build {  
-  val pico_atomic               = "org.pico"        %%  "pico-atomic"               % "0.2.0-7"
+  val pico_atomic               = "org.pico"        %%  "pico-atomic"               % "0.2.0-9"
 
   val specs2_core               = "org.specs2"      %%  "specs2-core"               % "3.7.2"
 


### PR DESCRIPTION
…vs Disposer.close.  Fix concurrency bug.  Use latest pico-atomic.  Use .value method instead of .get.  Only catch non-fatal exceptions.  More tests.  Smarter asCloseable method that avoids creating unnecessary wrapper if possible.  More tests.
