### PR TITLE
Pr new version 57db99b

### DIFF
--- a/pico-disposal/src/main/scala/org/pico/disposal/Disposable.scala
+++ b/pico-disposal/src/main/scala/org/pico/disposal/Disposable.scala
@@ -2,8 +2,6 @@ package org.pico.disposal
 
 import java.io.Closeable
 
-import scala.util.control.NonFatal
-
 /** Type trait for objects that can be disposed.  An instance is provided for AutoCloseable.
   * Additional instances may be provided for types that are not Closeable, particularly those found
   * in third-party libraries.
@@ -51,7 +49,7 @@ trait Disposable[-A] {
     * @param a The disposable object
     */
   @inline
-  final def dispose(a: A): Unit = try onDispose(a) catch { case NonFatal(e) => }
+  final def dispose(a: A): Unit = onDispose(a)
 }
 
 object Disposable {

--- a/pico-disposal/src/main/scala/org/pico/disposal/FailedDisposeException.scala
+++ b/pico-disposal/src/main/scala/org/pico/disposal/FailedDisposeException.scala
@@ -1,0 +1,13 @@
+package org.pico.disposal
+
+class FailedDisposeException(
+    message: String,
+    causes: List[Throwable]) extends Exception(message, causes.headOption.orNull) {
+  def this(causes: List[Throwable]) = this(null, causes)
+
+  def this(message: String) = this(message, List.empty)
+
+  def this() = this(null, List.empty)
+
+  override def getMessage: String = s"${super.getMessage} [${causes.mkString(", ")}]"
+}

--- a/pico-disposal/src/main/scala/org/pico/disposal/SilencedExceptions.scala
+++ b/pico-disposal/src/main/scala/org/pico/disposal/SilencedExceptions.scala
@@ -1,0 +1,16 @@
+package org.pico.disposal
+
+import java.util.concurrent.atomic.AtomicReference
+import org.pico.atomic.syntax.std.atomicReference._
+
+object SilencedExceptions {
+  private val subscriptions = new AtomicReference(List.empty[Throwable => Unit])
+
+  def subscribe(f: Throwable => Unit): Unit = subscriptions.update(f :: _)
+
+  def publish(t: Throwable): Unit = {
+    subscriptions.get.foreach { subscription =>
+      subscription(t)
+    }
+  }
+}

--- a/pico-disposal/src/test/scala/org/pico/disposal/DisposableSpec.scala
+++ b/pico-disposal/src/test/scala/org/pico/disposal/DisposableSpec.scala
@@ -56,11 +56,11 @@ class DisposableSpec extends Specification {
       Closed.asAutoCloseable must_=== Closed
     }
 
-    "have dispose method that suppresses exception" in {
+    "have dispose method that does not suppress exception" in {
       class NewType()
       implicit val disposable_NewType = Disposable[NewType](_ => throw new Exception())
       val newType = new NewType()
-      newType.dispose()
+      newType.dispose() must throwA[Exception]
       ok
     }
   }

--- a/pico-disposal/src/test/scala/org/pico/disposal/DisposerSpec.scala
+++ b/pico-disposal/src/test/scala/org/pico/disposal/DisposerSpec.scala
@@ -152,5 +152,28 @@ class DisposerSpec extends Specification {
         weakRef.get() must be_==(null).eventually(1, 100.millis)
       }
     }
+
+    "continue disposing in event of exception" in {
+      case class Exception1() extends Exception
+      case class Exception2() extends Exception
+
+      val disposer = Disposer()
+
+      var accumulator = List.empty[Int]
+
+      disposer.disposes(OnClose {
+        accumulator ::= 1
+        throw Exception1()
+      })
+
+      disposer.disposes(OnClose {
+        accumulator ::= 2
+        throw Exception2()
+      })
+
+      disposer.dispose() must throwA[FailedDisposeException]
+
+      accumulator.reverse ==== List(2, 1)
+    }
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,11 +7,13 @@ object Build extends sbt.Build {
 
   val specs2_core               = "org.specs2"      %%  "specs2-core"               % "3.8.6"
 
+  def env(name: String): Option[String] = Option(System.getenv(name))
+
   implicit class ProjectOps(self: Project) {
     def standard(theDescription: String) = {
       self
           .settings(scalacOptions in Test ++= Seq("-Yrangepos"))
-          .settings(publishTo := Some("Releases" at Option(System.getenv("PICO_PUBLISH_TO")).getOrElse("no-publishing")))
+          .settings(publishTo := env("PICO_PUBLISH_TO").map("Releases" at _))
           .settings(description := theDescription)
           .settings(isSnapshot := true)
           .settings(tutSettings: _*)


### PR DESCRIPTION
* Allow `dispose` method to throw `FailedDisposeException` and fatal exceptions.
* Introduce new `disposeSilently` method.
* New `SilencedExceptions` singleton that publishes exceptions that were silenced.